### PR TITLE
Rb/changes to generate centerline method

### DIFF
--- a/configuration.json
+++ b/configuration.json
@@ -1,8 +1,8 @@
 {
 	
-	"path_data": "./template_data",
+	"path_data": "/home/GRAMES.POLYMTL.CA/robana/duke/projects/template_dog_virginiatech/template_data/",
 
-	"path_template": "./prelim_template",
+	"path_template": "/home/GRAMES.POLYMTL.CA/robana/duke/projects/template_dog_virginiatech/prelim_template/",
 
 	"subjects": ["Harshman_Dobby", "Jacobsen_Petri"],
 

--- a/configuration.json
+++ b/configuration.json
@@ -1,0 +1,12 @@
+{
+	
+	"path_data": "./template_data",
+
+	"path_template": "./prelim_template",
+
+	"subjects": ["Harshman_Dobby", "Jacobsen_Petri"],
+
+	"suffix_centerline": "_centerline",
+	"suffix_disks": "_disks"
+
+}

--- a/configuration.json
+++ b/configuration.json
@@ -1,8 +1,8 @@
 {
 	
-	"path_data": "/home/GRAMES.POLYMTL.CA/robana/duke/projects/template_dog_virginiatech/template_data/",
+	"path_data": "./template_data/",
 
-	"path_template": "/home/GRAMES.POLYMTL.CA/robana/duke/projects/template_dog_virginiatech/prelim_template/",
+	"path_template": "./prelim_template/",
 
 	"subjects": ["Harshman_Dobby", "Jacobsen_Petri"],
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -6,29 +6,27 @@ The default dataset is an example dataset that is downloaded at the beginning of
 from preprocessing import *
 
 # downloading data and configuration file from OSF
-path_data = download_data_template(path_data='./')
+path_data = "/home/GRAMES.POLYMTL.CA/robana/duke/projects/template_dog_virginiatech/template_data/"
 
 # extracting info from dataset
-dataset_info = read_dataset(path_data + 'configuration.json', path_data=path_data)
+dataset_info = read_dataset('configuration.json')
 
 # generating centerlines
-list_centerline = generate_centerline(dataset_info=dataset_info, contrast='t1', regenerate=True)
+list_centerline = generate_centerline(dataset_info=dataset_info, contrast='t1',  regenerate=True)
+# list_centerline = generate_centerline(dataset_info=dataset_info, contrast='t2', regenerate=True)
 
 # computing average template centerline and vertebral distribution
-points_average_centerline, position_template_disks = average_centerline(list_centerline=list_centerline,
-                                                                        dataset_info=dataset_info,
-                                                                        use_ICBM152=False,
-                                                                        use_label_ref='C1')
+points_average_centerline, position_template_disks = average_centerline(list_centerline=list_centerline, dataset_info=dataset_info, use_ICBM152=False, use_label_ref='C1')
 
-# generating the initial template space
+# # generating the initial template space
 generate_initial_template_space(dataset_info=dataset_info,
                                 points_average_centerline=points_average_centerline,
                                 position_template_disks=position_template_disks)
 
-# straightening of all spinal cord
+# # straightening of all spinal cord
 straighten_all_subjects(dataset_info=dataset_info, contrast='t1')
 
-# normalize image intensity inside the spinal cord
+# # normalize image intensity inside the spinal cord
 normalize_intensity_template(dataset_info=dataset_info,
                              fname_template_centerline=dataset_info['path_template'] + 'template_centerline.npz',
                              contrast='t1',

--- a/pipeline.py
+++ b/pipeline.py
@@ -6,7 +6,7 @@ The default dataset is an example dataset that is downloaded at the beginning of
 from preprocessing import *
 
 # downloading data and configuration file from OSF
-path_data = "/home/GRAMES.POLYMTL.CA/robana/duke/projects/template_dog_virginiatech/template_data/"
+path_data = "./template_data/"
 
 # extracting info from dataset
 dataset_info = read_dataset('configuration.json')
@@ -27,13 +27,13 @@ generate_initial_template_space(dataset_info=dataset_info,
 straighten_all_subjects(dataset_info=dataset_info, contrast='t1')
 
 # # normalize image intensity inside the spinal cord
-normalize_intensity_template(dataset_info=dataset_info,
-                             fname_template_centerline=dataset_info['path_template'] + 'template_centerline.npz',
-                             contrast='t1',
-                             verbose=1)
+# normalize_intensity_template(dataset_info=dataset_info,
+#                              fname_template_centerline=dataset_info['path_template'] + 'template_centerline.npz',
+#                              contrast='t1',
+#                              verbose=1)
 
-# copy preprocessed dataset in template folder
-copy_preprocessed_images(dataset_info=dataset_info, contrast='t1')
+# # copy preprocessed dataset in template folder
+# copy_preprocessed_images(dataset_info=dataset_info, contrast='t1')
 
-# converting results to Minc format
-convert_data2mnc(dataset_info, contrast='t1')
+# # converting results to Minc format
+# convert_data2mnc(dataset_info, contrast='t1')


### PR DESCRIPTION
This PR updates the generate_centerline() method.

#### Why this update?
The previous version of this code expected the user to upload the centreline in the .npz or calculate and save the centreline using the get_centerline method. It was discovered that the previous version of this method, even though the centreline was calculated properly, the values returned values were in the pixel space and not converted into the physical space. 

This led to calculation of values in subsequent methods like distance of discs from C1.

The **_get_centerline** method [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/master/spinalcordtoolbox/straightening.py) converts the values into physical space and returns those values which are crucial from the the subsequent methods in the template generation pipeline and solves the above mentioned bug.

Collaborators on the PR: Benjamin De Leener and Rohan Banerjee

