### PR TITLE
Rb/remove_save_centerline

### DIFF
--- a/template_preprocessing.py
+++ b/template_preprocessing.py
@@ -184,8 +184,6 @@ def generate_centerline(dataset_info, lowest_disc = 25, contrast = 't1', regener
         im_ctl.save(fname_centerline + '.nii.gz', dtype = 'float32')
         centerline = Centerline(points_x = arr_ctl[0], points_y = arr_ctl[1], points_z = arr_ctl[2], deriv_x = arr_ctl_der[0], deriv_y = arr_ctl_der[1], deriv_z = arr_ctl_der[2])
         centerline.compute_vertebral_distribution(coord_physical)
-        # save centerline .npz file
-        centerline.save_centerline(fname_output = fname_centerline)
 
         list_centerline.append(centerline)
         tqdm_bar.update(1)

--- a/template_preprocessing.py
+++ b/template_preprocessing.py
@@ -158,39 +158,34 @@ def generate_centerline(dataset_info, lowest_disc = 25, contrast = 't1', regener
         fname_image_discs = fname_discs + '-manual.nii.gz' if os.path.isfile(fname_discs + '-manual.nii.gz') else fname_discs + '.nii.gz'
         fname_centerline = path_data + 'derivatives/labels/' + subject_name +  '/' + dataset_info['data_type'] + '/' + subject_name + dataset_info['suffix_image'] + '_label-centerline'
 
-        # if centerline exists, we load it, if not, we compute it
-        if os.path.isfile(fname_centerline + '.npz') and not regenerate:
-            print("Centerline for " + subject_name + " exists and will not be recomputed!")
-            centerline = Centerline(fname = fname_centerline + '.npz')
+        if os.path.isfile(fname_image_seg):
+            print(subject_name + ' SC segmentation exists. Extracting centerline from ' + fname_image_seg)
+            im_seg = Image(fname_image_seg).change_orientation('RPI')
+            param_centerline = ParamCenterline(algo_fitting = algo_fitting, contrast = contrast, smooth = smooth, degree = degree, minmax = minmax) 
         else:
-            if os.path.isfile(fname_image_seg):
-                print(subject_name + ' SC segmentation exists. Extracting centerline from ' + fname_image_seg)
-                im_seg = Image(fname_image_seg).change_orientation('RPI')
-                param_centerline = ParamCenterline(algo_fitting = algo_fitting, contrast = contrast, smooth = smooth, degree = degree, minmax = minmax) 
-            else:
-                print(subject_name + ' SC segmentation does not exist. Extracting centerline from ' + fname_image)
-                im_seg = Image(fname_image).change_orientation('RPI')
-                param_centerline = ParamCenterline(algo_fitting = 'optic', contrast = contrast, smooth = smooth, degree = 5, minmax = minmax)
+            print(subject_name + ' SC segmentation does not exist. Extracting centerline from ' + fname_image)
+            im_seg = Image(fname_image).change_orientation('RPI')
+            param_centerline = ParamCenterline(algo_fitting = 'optic', contrast = contrast, smooth = smooth, degree = 5, minmax = minmax)
 
-            # extracting intervertebral discs
-            im_discs = Image(fname_image_discs).change_orientation('RPI')
-            coord = im_discs.getNonZeroCoordinates(sorting = 'z', reverse_coord = True)
-            coord_physical = []
-            for c in coord:
-                if c.value <= lowest_disc or c.value in [48, 49, 50, 51, 52]:
-                    c_p = list(im_discs.transfo_pix2phys([[c.x, c.y, c.z]])[0])
-                    c_p.append(c.value)
-                    coord_physical.append(c_p)
+        # extracting intervertebral discs
+        im_discs = Image(fname_image_discs).change_orientation('RPI')
+        coord = im_discs.getNonZeroCoordinates(sorting = 'z', reverse_coord = True)
+        coord_physical = []
+        for c in coord:
+            if c.value <= lowest_disc or c.value in [48, 49, 50, 51, 52]:
+                c_p = list(im_discs.transfo_pix2phys([[c.x, c.y, c.z]])[0])
+                c_p.append(c.value)
+                coord_physical.append(c_p)
 
-            # extracting centerline
-            im_ctl, arr_ctl, arr_ctl_der, _ = get_centerline(im_seg, param = param_centerline)
+        # extracting centerline
+        im_ctl, arr_ctl, arr_ctl_der, _ = get_centerline(im_seg, param = param_centerline)
 
-            # save centerline as .nii.gz file
-            im_ctl.save(fname_centerline + '.nii.gz', dtype = 'float32')
-            centerline = Centerline(points_x = arr_ctl[0], points_y = arr_ctl[1], points_z = arr_ctl[2], deriv_x = arr_ctl_der[0], deriv_y = arr_ctl_der[1], deriv_z = arr_ctl_der[2])
-            centerline.compute_vertebral_distribution(coord_physical)
-            # save centerline .npz file
-            centerline.save_centerline(fname_output = fname_centerline)
+        # save centerline as .nii.gz file
+        im_ctl.save(fname_centerline + '.nii.gz', dtype = 'float32')
+        centerline = Centerline(points_x = arr_ctl[0], points_y = arr_ctl[1], points_z = arr_ctl[2], deriv_x = arr_ctl_der[0], deriv_y = arr_ctl_der[1], deriv_z = arr_ctl_der[2])
+        centerline.compute_vertebral_distribution(coord_physical)
+        # save centerline .npz file
+        centerline.save_centerline(fname_output = fname_centerline)
 
         list_centerline.append(centerline)
         tqdm_bar.update(1)


### PR DESCRIPTION
Removing the line `centerline.save_centerline(fname_output = fname_centerline)` since it is not required. The centrelines are getting appended to the the `list_centerline` list which is what the `get_centerline` method returns. 

Solves the second part of the issue https://github.com/neuropoly/template/issues/34#issue-1781119134