### PR TITLE
Removal of hard-coded `configuration` file in `preprocess_segment.sh` script and extraction of `include_list` from the `configuration` file directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ conda activate venv_sct
 Copy the file `configuration_default.json` and rename it as `configuration.json`. Edit it and modify according to your setup:
 
 - `path_data`: Absolute path to the input [BIDS dataset](#dataset-structure); the path should end with `/`.
-- `include-list`: List of subjects to include in the preprocessing, separated with a space.
+- `include_list`: List of subjects to include in the preprocessing, separated with a space.
 - `data_type`: [BIDS data type](https://bids-standard.github.io/bids-starter-kit/folders_and_files/folders.html#datatype), same as subfolder name in dataset structure. Typically, it should be "anat".
 - `contrast`: Contrast to be used by `sct_deepseg_sc` function.
 - `suffix_image`: Suffix for image data, after subject ID but before file extension (e.g. `_rec-composed_T1w` in `sub-101_rec-composed_T1w.nii.gz`).
@@ -115,15 +115,14 @@ Copy the file `configuration_default.json` and rename it as `configuration.json`
 
 Run script:
 ```
-sct_run_batch -script preprocess_segment.sh -config configuration.json -include-list sub-001 sub-002 sub-003 -path-output PATH_OUT -jobs N_CPU
+sct_run_batch -script preprocess_segment.sh -config configuration.json -path-output PATH_OUT -jobs N_CPU -script-args configuration.json
 ```
+> **Note**
+> The value `configuration.json` should be the same from both the flags `-config` and `-script-args`.
 
 With:
 - `PATH_OUT`: The location where to output the processed data, results, the logs and the QC information. Example: `/scratch/template_preproc_YYYYMMDD-HHMMSS`. This is a temporary directory in that it is only needed to QC your labels. It therefore cannot be stored inside `path_data`.
 - `N_CPU`: The number of CPU cores to dedicate to this task (one subject will be process per core).
-
-> **Note**
-> Copy-paste the values to the `include-list` key from `configuration.json` to go after `-include-list` option here.
 
 ### 1.4 Quality control (QC) labels
 

--- a/configuration_default.json
+++ b/configuration_default.json
@@ -1,6 +1,6 @@
 {
 	"path_data": "/path/to/data/",
-	"include-list": "sub-001 sub-002 sub-003",
+	"include_list": "sub-001 sub-002 sub-003",
 	"data_type": "anat",
 	"contrast": "t1",
 	"suffix_image": "_T1w",

--- a/preprocess_normalize.py
+++ b/preprocess_normalize.py
@@ -101,7 +101,7 @@ def read_dataset(fname_json = 'configuration.json', path_data = './'):
     with open(fname_json) as data_file: dataset_info = json.load(data_file)
 
     error = ''
-    key_list = ["path_data", "include-list", "data_type", "contrast", "suffix_image", "last_disc"]
+    key_list = ["path_data", "include_list", "data_type", "contrast", "suffix_image", "last_disc"]
 
     for key in key_list:
         if key not in dataset_info.keys(): error += 'Dataset configuration file ' + fname_json + ' must contain the field ' + key + '.\n'
@@ -121,7 +121,7 @@ def generate_centerline(dataset_info, algo_fitting = 'linear', smooth = 50, degr
     :return list of centerline objects
     """
     path_data = dataset_info['path_data']
-    list_subjects = dataset_info['include-list'].split(' ')
+    list_subjects = dataset_info['include_list'].split(' ')
     last_disc = int(dataset_info['last_disc'])
     list_centerline = []
     current_path = os.getcwd()
@@ -468,7 +468,7 @@ def straighten_all_subjects(dataset_info, normalized = False):
     """
     path_data = dataset_info['path_data']
     path_template = dataset_info['path_data'] + 'derivatives/template/'
-    list_subjects = dataset_info['include-list'].split(' ')
+    list_subjects = dataset_info['include_list'].split(' ')
 
     if not os.path.exists(dataset_info['path_data'] + 'derivatives/sct_straighten_spinalcord'): os.makedirs(dataset_info['path_data'] + 'derivatives/sct_straighten_spinalcord')
 
@@ -509,7 +509,7 @@ def normalize_intensity_template(dataset_info, verbose = 1):
     :return:
     """
     fname_template_centerline = dataset_info['path_data'] + 'derivatives/template/' + 'template_label-centerline.npz'
-    list_subjects = dataset_info['include-list'].split(' ')
+    list_subjects = dataset_info['include_list'].split(' ')
 
     average_intensity = []
     intensity_profiles = {}
@@ -616,7 +616,7 @@ def normalize_intensity_template(dataset_info, verbose = 1):
         image_new.save(fname_image_normalized)
 
 def copy_preprocessed_images(dataset_info):
-    list_subjects = dataset_info['include-list'].split(' ') 
+    list_subjects = dataset_info['include_list'].split(' ') 
     
     tqdm_bar = tqdm(total = len(list_subjects), unit = 'B', unit_scale = True, desc = "Status", ascii = True)
     
@@ -628,7 +628,7 @@ def copy_preprocessed_images(dataset_info):
 
 def create_mask_template(dataset_info):
     path_template = dataset_info['path_data'] + 'derivatives/template/'
-    subject_name = dataset_info['include-list'].split(' ')[0]
+    subject_name = dataset_info['include_list'].split(' ')[0]
 
     template_mask = Image(path_template + subject_name + dataset_info['suffix_image'] + '_straight_norm.nii.gz')
     template_mask.data *= 0.0
@@ -643,7 +643,7 @@ def create_mask_template(dataset_info):
 
 def convert_data2mnc(dataset_info):
     path_template = dataset_info['path_data'] + 'derivatives/template/'
-    list_subjects = dataset_info['include-list'].split(' ')
+    list_subjects = dataset_info['include_list'].split(' ')
 
     path_template_mask = create_mask_template(dataset_info)
 


### PR DESCRIPTION
This PR solves the issues #72 and #73 

### What this PR solves:
- In the `preprocess_segment.sh`, the `configuration.json` file was hard-coded which meant whatever we pass as a value the `-config` flag, it will read only the `configuration.json` from the script. This PR takes the `configuration.json` from the `sct_run_batch` command rather than a hard-coded value.
- We are also passing the values to `--include-list` while running the `preprocessing.sh` using `sct_run_batch` even when the values are already mentioned in the `include-list` in the `configuration.json`. This PR helps the `sct_run_batch` to take this value directly from the `configuration.json` file.

### Steps to reproduce this PR:
Data: `duke/temp/rohan/bids_data`
Config file values:

```json
{
	"path_data": "PATH_TO_BIDS_DATA",
	"include-list": "sub-HarshmanDobby",
	"data_type": "anat",
	"contrast": "t2",
	"suffix_image": "_T2",
	"first_disc": "1",
	"last_disc": "26"
}
```

Run the `preprocess_segment.sh` using the `sct_run_batch` from the `README` of this PR. 

### Expected output
Running this script should create a temporary output folder with the `segmentation` and `disc_level` derivatives with the names:
{SUBJECT_NAME_CONTRAST}_label-SC_mask.nii.gz
{SUBJECT_NAME_CONTRAST}_labeled-discs.nii.gz