### PR TITLE
Adding the preprocessing code back

### DIFF
--- a/preprocess_segment.sh
+++ b/preprocess_segment.sh
@@ -90,15 +90,34 @@ rsync -avzh $PATH_DATA/$SUBJECT/$DATA_TYPE/${SUBJECT}${IMAGE_SUFFIX}.nii.gz $PAT
 # ======================================================================================================================
 
 FILESEG="${SUBJECT}${IMAGE_SUFFIX}_label-SC_mask.nii.gz"
-sct_deepseg_sc -i ${FILE} -o ${FILESEG} -c ${CONTRAST} -qc ${PATH_QC} -qc-subject ${SUBJECT}
 
+echo "Looking for segmentation: ${FILESEG}"
+if [[ -e "${FILESEG}" ]]; then
+  echo "Found! Using SC segmentation that exists."
+  sct_qc -i ${FILE} -s "${FILESEG}" -p sct_deepseg_sc -qc ${PATH_QC} -qc-subject ${SUBJECT}
+else
+  echo "Not found. Proceeding with automatic segmentation."
+  # Segment spinal cord
+  sct_deepseg_sc -i ${FILE} -o ${FILESEG} -c ${CONTRAST} -qc ${PATH_QC} -qc-subject ${SUBJECT}
+fi
 # Label discs if do not exist
 # ======================================================================================================================
 
-FILELABEL="${SUBJECT}${IMAGE_SUFFIX}_labeled-discs.nii.gz"
-sct_label_vertebrae -i ${FILE} -s "${FILESEG}" -c ${CONTRAST} -qc "${PATH_QC}" -qc-subject "${SUBJECT}"
-mv "${SUBJECT}${IMAGE_SUFFIX}_label-SC_mask_labeled_discs.nii.gz" "${FILELABEL}"
-rm "${SUBJECT}${IMAGE_SUFFIX}_label-SC_mask_labeled.nii.gz"
+FILELABEL="${SUBJECT}${IMAGE_SUFFIX}_labels-disc.nii.gz"
+
+ echo "Looking for disc labels: ${FILELABEL}"
+if [[ -e "${FILELABEL}" ]]; then
+  echo "Found! Using vertebral labels that exist."
+  sct_qc -i ${FILE} -s "${FILELABEL}" -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}
+else
+  echo "Not found. Proceeding with automatic labeling."
+  # Generate labeled segmentation
+  sct_label_vertebrae -i ${FILE} -s "${FILESEG}" -c ${CONTRAST} -qc "${PATH_QC}" -qc-subject "${SUBJECT}"
+  mv "${SUBJECT}${IMAGE_SUFFIX}_label-SC_seg_labeled_discs.nii.gz" "${FILELABEL}"
+  rm "${SUBJECT}${IMAGE_SUFFIX}_label-SC_seg_labeled.nii.gz"
+  mv "${SUBJECT}${IMAGE_SUFFIX}_label-SC_mask_labeled_discs.nii.gz" "${FILELABEL}"
+  rm "${SUBJECT}${IMAGE_SUFFIX}_label-SC_mask_labeled.nii.gz"
+fi
 
 # Verify presence of output files and write log file if error
 # ======================================================================================================================


### PR DESCRIPTION
Fixes #80. Adds the removed code back to `preprocess_segment.sh`.

### Steps to reproduce this PR:
Data: `duke/temp/rohan/bids_data`
Config file values:

```json
{
	"path_data": "PATH_TO_BIDS_DATA",
	"include-list": "sub-HarshmanDobby",
	"data_type": "anat",
	"contrast": "t2",
	"suffix_image": "_T2",
	"first_disc": "1",
	"last_disc": "26"
}
```

Run the `preprocess_segment.sh` using the `sct_run_batch` from the `README` of this PR. 

### Expected output
Running this script should create a temporary output folder with the `segmentation` and `disc_level` derivatives with the names:
{SUBJECT_NAME_CONTRAST}_label-SC_mask.nii.gz
{SUBJECT_NAME_CONTRAST}_labeled-discs.nii.gz