### PR TITLE
Straighten spinal cord now includes all disc levels as mentioned in the `last_disc` parameter in the `configuration.json` file

### DIFF
--- a/preprocess_normalize.py
+++ b/preprocess_normalize.py
@@ -675,6 +675,8 @@ def main(configuration_file):
     Pipeline for data processing.
     """
     dataset_info = read_dataset(configuration_file)
+    Centerline.list_labels = [50, 49] + list(range(int(dataset_info['last_disc']) + 1))
+
 
     # generating centerlines
     list_centerline = generate_centerline(dataset_info = dataset_info)


### PR DESCRIPTION
Fixes #65 

### Context:
Initial pipeline limited the disc levels until 23 since the value of the `list_label` list which was imported from the `Centerline` method in `SCT` were only till 23

### How this PR solves the issue:
The pipeline now dynamically creates a `list_label` whose max value is taken on the basis of the specified value in `last_disc` in the `configuration.json` file.