### PR TITLE
Creation of `subjects.csv` in the correct path and fixing minor bugs in the path name

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,9 @@ e) Minc2simple
 ```
 pip install "git+https://github.com/NIST-MNI/minc2-simple.git@develop_new_build#subdirectory=python"
 ``` 
+f) Update the absolute of the `subjects.csv` in the `generate_template.py` script. The `subjects.csv` lies inside the `DATASET/derivatives/template` directory
 
-f) Create `template_pipleline.sh` 
+g) Create `template_pipleline.sh` 
 > **Note:**
 > Create the `template_pipeline.sh` inside the `template` folder.
 ```
@@ -234,12 +235,12 @@ f) Create `template_pipleline.sh`
 python -m scoop -vvv generate_template.py
 ```
 
-g) Batch on Alliance Canada
+h) Batch on Alliance Canada
 ```
 sbatch --time=24:00:00  --mem-per-cpu 4000 template_pipeline.sh # will probably require batching several times, depending on number of subjects
 ```
 
-h) Final output
+i) Final output
 <p>After the pipeline has finished running, the `.mnc` file needs to be converted to `.nii` format in order to get the final template. The pipeline would give outputs with the name: avg.XXX.mnc, where `XXX` is the nth iteration. To convert it to the `.nii` format, run the following command:</p>
 
 ```

--- a/preprocess_normalize.py
+++ b/preprocess_normalize.py
@@ -675,7 +675,6 @@ def main(configuration_file):
     Pipeline for data processing.
     """
     dataset_info = read_dataset(configuration_file)
-    Centerline.list_labels = [50, 49] + list(range(int(dataset_info['last_disc']) + 1))
 
     # generating centerlines
     list_centerline = generate_centerline(dataset_info = dataset_info)

--- a/preprocess_normalize.py
+++ b/preprocess_normalize.py
@@ -639,7 +639,7 @@ def create_mask_template(dataset_info):
     if os.path.isfile(path_template + '/template_mask.mnc'): os.remove(path_template + '/template_mask.mnc')
 
     os.system('nii2mnc ' + path_template + '/template_mask.nii.gz ' + ' ' + path_template + '/template_mask.mnc')
-    return path_template + '/template_mask.mnc'
+    return path_template + 'template_mask.mnc'
 
 def convert_data2mnc(dataset_info):
     path_template = dataset_info['path_data'] + 'derivatives/template/'
@@ -647,7 +647,7 @@ def convert_data2mnc(dataset_info):
 
     path_template_mask = create_mask_template(dataset_info)
 
-    output_list = open('subjects.csv', "w")
+    output_list = open(path_template + 'subjects.csv', "w")
     writer = csv.writer(output_list, delimiter = ',', quotechar = ',', quoting = csv.QUOTE_MINIMAL)
 
     tqdm_bar = tqdm(total = len(list_subjects), unit = 'B', unit_scale = True, desc = "Status", ascii = True)
@@ -661,7 +661,7 @@ def convert_data2mnc(dataset_info):
         os.system('nii2mnc ' + fname_nii + ' ' + fname_mnc)
         os.remove(fname_nii) # remove duplicate nifti file!
 
-        writer.writerow([fname_mnc,path_template_mask])
+        writer.writerow([fname_mnc, path_template_mask])
 
         tqdm_bar.update(1)
     tqdm_bar.close()
@@ -676,7 +676,6 @@ def main(configuration_file):
     """
     dataset_info = read_dataset(configuration_file)
     Centerline.list_labels = [50, 49] + list(range(int(dataset_info['last_disc']) + 1))
-
 
     # generating centerlines
     list_centerline = generate_centerline(dataset_info = dataset_info)

--- a/preprocess_normalize.py
+++ b/preprocess_normalize.py
@@ -675,6 +675,8 @@ def main(configuration_file):
     Pipeline for data processing.
     """
     dataset_info = read_dataset(configuration_file)
+    Centerline.list_labels = [50, 49] + list(range(int(dataset_info['last_disc']) + 1))
+
 
     # generating centerlines
     list_centerline = generate_centerline(dataset_info = dataset_info)


### PR DESCRIPTION
Fixes #83 

### Context:
- The `subjects.csv` is the file which is use by the `generate_template.py` to read specific files that are used for the template creation. The issue right now was that the `subjects.csv` file was created in the `<DATASET>/derivatives/sct_straighten_spinalcord/<LAST_SUBJECT>`. 
- Along with this, there was a minor bug in the pathname that was appended in the `subject.csv` leading to the need of manual correction of the pathname.
- There was no clear instruction in the README as to change the pathname of `subjects.csv` in the `generate_template.py` script.

### What does the PR solve:
The PR solves the above issues.
- The `subjects.csv` file with the correct pathnames are now created inside the `<DATASET>/derivatives/template` making it easier to find.
- Also provides with the clear instructions to change pathname in the `generate_template.py`

 It has been tested on the Dog data ✅ 